### PR TITLE
build: disable renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
   "labels": ["dep"],
   "schedule": ["before 9am"],
   "branchPrefix": "upgrade-renovate-",
+  "dependencyDashboard": false,
   "ignorePaths": [".github/"],
   "major": {
     "stabilityDays": 5


### PR DESCRIPTION
## Overview

disable renovate dependency dashboard

<!-- Summarize what do you want add in this PR. -->

Fixes #3

## Feature type

<!-- Select which type of feature you want to add. -->

- [ ] Lint Rule
- [ ] Quick fix
- [ ] Assist
- [x] Other (Update docs, Configure CI, etc...)
