### PR TITLE
build: use yq to extract melos version

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -17,7 +17,7 @@ runs:
       id: melos
       uses: mikefarah/yq@0b34c9a00de1c575a34eea05af1d956a525c4fc1 # v4.34.2
       with:
-        cmd: '.dev_dependencies.melos' ./pubspec.yaml
+        cmd: yq '.dev_dependencies.melos' './pubspec.yaml'
     - name: Download Melos and bootstrap
       uses: bluefireteam/melos-action@dd3c344d731938d2ab2567a261f54a19a68b5f6a # v2
       with:

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -15,14 +15,13 @@ runs:
         cache: true
     - name: Extract Melos version from pubspec
       id: melos
-      uses: jbutcher5/read-yaml@39cf058cf4ea746b66d7f49f4da10a81204450cc # v1.6
+      uses: mikefarah/yq@0b34c9a00de1c575a34eea05af1d956a525c4fc1 # v4.34.2
       with:
-        file: './pubspec.yaml'
-        key-path: '["dev_dependencies", "melos"]'
+        cmd: '.dev_dependencies.melos' ./pubspec.yaml
     - name: Download Melos and bootstrap
       uses: bluefireteam/melos-action@dd3c344d731938d2ab2567a261f54a19a68b5f6a # v2
       with:
-        melos-version: ${{ steps.melos.outputs.data }}
+        melos-version: ${{ steps.melos.outputs.result }}
         run-bootstrap: true
     - name: Install others
       shell: bash


### PR DESCRIPTION
## Overview

Use [yq](https://github.com/mikefarah/yq) to extract Melos version from pubspec.yaml instead of [read-yaml](https://github.com/jbutcher5/read-yaml) which was archived.

<!-- Summarize what do you want add in this PR. -->

## Feature type

<!-- Select which type of feature you want to add. -->

- [ ] Lint Rule
- [ ] Quick fix
- [ ] Assist
- [x] Other (Update docs, Configure CI, etc...)