### PR TITLE
feat: add  quick fix for fixed_text_scale_rich_text

### DIFF
--- a/packages/nilts/README.md
+++ b/packages/nilts/README.md
@@ -125,12 +125,21 @@ final VoidCallback callback;
 - Maturity level: Experimental
 - Quick fix: ✅
 
-**Consider** adding `textScaler` or `textScaleFactor` (deprecated on Flutter 3.16.0 and above) argument to [RichText] constructor to make the text size responsive for user setting.  
+**Consider** using `Text.rich` or adding `textScaler` or `textScaleFactor` (deprecated on Flutter 3.16.0 and above) argument to [RichText] constructor to make the text size responsive for user setting.  
 
 **BAD:**
 ```dart
 RichText(
   text: TextSpan(
+    text: 'Hello, world!',
+  ),
+)
+```
+
+**GOOD:**
+```dart
+Text.rich(
+  TextSpan(
     text: 'Hello, world!',
   ),
 )
@@ -157,7 +166,8 @@ RichText(
 ```
 
 See also:
-
+                           
+- [Text.rich constructor - Text - widgets library - Dart API](https://api.flutter.dev/flutter/widgets/Text/Text.rich.html)
 - [RichText class - widgets library - Dart API](https://api.flutter.dev/flutter/widgets/RichText-class.html)
 
 #### flaky_tests_with_set_up_all

--- a/packages/nilts/lib/src/change_priority.dart
+++ b/packages/nilts/lib/src/change_priority.dart
@@ -9,10 +9,10 @@
 ///   - [IgnoreCode](https://github.com/invertase/dart_custom_lint/blob/1df2851a80ccdc5a2bda4418006560f49c03b8ec/packages/custom_lint_builder/lib/src/ignore.dart#L102)
 class ChangePriority {
   /// The priority for [_AddTextScaleFactor].
-  static const int addTextScaleFactor = 100;
+  static const int addTextScaleFactor = 90;
 
   /// The priority for [_AddTextScaler].
-  static const int addTextScaler = 100;
+  static const int addTextScaler = 90;
 
   /// The priority for [_RemoveShrinkWrap].
   static const int removeShrinkWrap = 100;
@@ -22,6 +22,9 @@ class ChangePriority {
 
   /// The priority for [_ReplaceWithSetUp].
   static const int replaceWithSetUp = 100;
+
+  /// The priority for [_ReplaceWithTextRich].
+  static const int replaceWithTextRich = 100;
 
   /// The priority for [_ReplaceWithVoidCallback].
   static const int replaceWithVoidCallback = 100;

--- a/packages/nilts_test/pubspec.yaml
+++ b/packages/nilts_test/pubspec.yaml
@@ -3,8 +3,8 @@ description: A new Flutter module project.
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.10.0'
+  sdk: '>=3.2.0 <4.0.0'
+  flutter: '>=3.16.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Overview

Add new quick fix for fixed_text_scale_rich_text lint rule.
Replace `RichText` with `Text.rich`.

<!-- Summarize what do you want add in this PR. -->

Fixes #<issue number>

## Feature type

<!-- Select which type of feature you want to add. -->

- [ ] Lint Rule
- [x] Quick fix
- [ ] Assist
- [ ] Other (Update docs, Configure CI, etc...)