### PR TITLE
feat: defined_value_changed_type and defined_value_setter_type

### DIFF
--- a/packages/nilts/README.md
+++ b/packages/nilts/README.md
@@ -92,6 +92,8 @@ Some of lint rules support quick fixes on IDE.
 
 | Rule name                                                                           | Overview                                                                       |           Target SDK           | Rule type | Maturity level | Quick fix |
 |:------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------|:------------------------------:| :-------: |:--------------:|:---------:|
+| [defined\_value\_changed\_type](#defined_value_changed_type)                        | Checks `void Function(T value)` definitions.                                   |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️     |
+| [defined\_value\_setter\_type](#defined_value_setter_type)                          | Checks `void Function(T value)` definitions.                                   |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️     |
 | [defined\_void\_callback\_type](#defined_void_callback_type)                        | Checks `void Function()` definitions.                                          |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️     |
 | [fixed\_text\_scale\_rich\_text](#fixed_text_scale_rich_text)                       | Checks usage of `textScaler` or `textScaleFactor` in `RichText` constructor.   |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️     |
 | [flaky\_tests\_with\_set\_up\_all](#flaky_tests_with_set_up_all)                    | Checks `setUpAll` usages.                                                      |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️     |
@@ -101,7 +103,67 @@ Some of lint rules support quick fixes on IDE.
 
 ### Details
 
+#### defined_value_changed_type
+
+<details>
+
+- Target SDK     : Any versions nilts supports
+- Rule type      : Practice
+- Maturity level : Experimental
+- Quick fix      : ✅
+
+**Consider** replace `void Function(T value)` with [ValueChanged] which is defined in Flutter SDK.  
+If the value has been set, use [ValueSetter] instead.
+
+**BAD:**
+```dart
+final void Function(int value) callback;
+```
+
+**GOOD:**
+```dart
+final ValueChanged<int> callback;
+```
+
+See also:
+
+- [ValueChanged typedef - foundation library - Dart API](https://api.flutter.dev/flutter/foundation/ValueChanged.html)
+- [ValueSetter typedef - foundation library - Dart API](https://api.flutter.dev/flutter/foundation/ValueSetter.html)
+
+</details>
+
+#### defined_value_setter_type
+
+<details>
+
+- Target SDK     : Any versions nilts supports
+- Rule type      : Practice
+- Maturity level : Experimental
+- Quick fix      : ✅
+
+**Consider** replace `void Function(T value)` with [ValueSetter] which is defined in Flutter SDK.  
+If the value has changed, use [ValueChanged] instead.
+
+**BAD:**
+```dart
+final void Function(int value) callback;
+```
+
+**GOOD:**
+```dart
+final ValueSetter<int> callback;
+```
+
+See also:
+
+- [ValueSetter typedef - foundation library - Dart API](https://api.flutter.dev/flutter/foundation/ValueSetter.html)
+- [ValueChanged typedef - foundation library - Dart API](https://api.flutter.dev/flutter/foundation/ValueChanged.html)
+
+</details>
+
 #### defined_void_callback_type
+
+<details>
 
 - Target SDK     : Any versions nilts supports
 - Rule type      : Practice
@@ -123,7 +185,15 @@ final void Function() callback;
 final VoidCallback callback;
 ```
 
+See also:
+
+- [VoidCallback typedef - dart:ui library - Dart API](https://api.flutter.dev/flutter/dart-ui/VoidCallback.html)
+
+</details>
+
 #### fixed_text_scale_rich_text
+
+<details>
 
 - Target SDK     : Any versions nilts supports
 - Rule type      : Practice
@@ -175,7 +245,11 @@ See also:
 - [Text.rich constructor - Text - widgets library - Dart API](https://api.flutter.dev/flutter/widgets/Text/Text.rich.html)
 - [RichText class - widgets library - Dart API](https://api.flutter.dev/flutter/widgets/RichText-class.html)
 
+</details>
+
 #### flaky_tests_with_set_up_all
+
+<details>
 
 - Target SDK     : Any versions nilts supports
 - Rule type      : Practice
@@ -216,7 +290,11 @@ See also:
 - [setUpAll function - flutter_test library - Dart API](https://api.flutter.dev/flutter/flutter_test/setUpAll.html)
 - [setUp function - flutter_test library - Dart API](https://api.flutter.dev/flutter/flutter_test/setUp.html)
 
+</details>
+
 #### no_support_multi_text_direction
+
+<details>
 
 - Target SDK     : Any versions nilts supports
 - Rule type      : Practice
@@ -279,7 +357,11 @@ See also:
 - [EdgeInsetsDirectional class - painting library - Dart API](https://api.flutter.dev/flutter/painting/EdgeInsetsDirectional-class.html)
 - [PositionedDirectional class - widgets library - Dart API](https://api.flutter.dev/flutter/widgets/PositionedDirectional-class.html)
 
+</details>
+
 #### shrink_wrapped_scroll_view
+
+<details>
 
 - Target SDK     : Any versions nilts supports
 - Rule type      : Practice
@@ -310,7 +392,11 @@ See also:
 - [shrinkWrap property - ScrollView class - widgets library - Dart API](https://api.flutter.dev/flutter/widgets/ScrollView/shrinkWrap.html)
 - [ShrinkWrap vs Slivers | Decoding Flutter - YouTube](https://youtu.be/LUqDNnv_dh0)
 
+</details>
+
 #### unnecessary_rebuilds_from_media_query
+
+<details>
 
 - Target SDK     : >= Flutter 3.10.0 (Dart 3.0.0)
 - Rule type      : Practice
@@ -341,6 +427,8 @@ See also:
 
 - [MediaQuery as InheritedModel by moffatman · Pull Request #114459 · flutter/flutter](https://github.com/flutter/flutter/pull/114459)
 - [MediaQuery class - widgets library - Dart API](https://api.flutter.dev/flutter/widgets/MediaQuery-class.html)
+
+</details>
 
 ## Assists
 

--- a/packages/nilts/lib/nilts.dart
+++ b/packages/nilts/lib/nilts.dart
@@ -1,5 +1,6 @@
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:nilts/src/dart_version.dart';
+import 'package:nilts/src/lints/defined_value_callback_type.dart';
 import 'package:nilts/src/lints/defined_void_callback_type.dart';
 import 'package:nilts/src/lints/fixed_text_scale_rich_text.dart';
 import 'package:nilts/src/lints/flaky_tests_with_set_up_all.dart';
@@ -17,6 +18,8 @@ class _NiltsLint extends PluginBase {
 
   @override
   List<LintRule> getLintRules(CustomLintConfigs configs) => [
+        const DefinedValueChangedType(),
+        const DefinedValueSetterType(),
         const DefinedVoidCallbackType(),
         if (_dartVersion >= const DartVersion(major: 3, minor: 2, patch: 0))
           const FixedTextScaleRichText()

--- a/packages/nilts/lib/src/change_priority.dart
+++ b/packages/nilts/lib/src/change_priority.dart
@@ -38,6 +38,12 @@ class ChangePriority {
   /// The priority for [_ReplaceWithTextRich].
   static const int replaceWithTextRich = 100;
 
+  /// The priority for [_ReplaceWithValueChanged].
+  static const int replaceWithValueChanged = 100;
+
+  /// The priority for [_ReplaceWithValueSetter].
+  static const int replaceWithValueSetter = 100;
+
   /// The priority for [_ReplaceWithVoidCallback].
   static const int replaceWithVoidCallback = 100;
 

--- a/packages/nilts/lib/src/lints/defined_value_callback_type.dart
+++ b/packages/nilts/lib/src/lints/defined_value_callback_type.dart
@@ -1,0 +1,174 @@
+// ignore_for_file: comment_references
+
+import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:nilts/src/change_priority.dart';
+
+/// A class for `defined_value_changed_type` rule.
+///
+/// This rule checks defining `void Function(T value)` type.
+///
+/// - Target SDK     : Any versions nilts supports
+/// - Rule type      : Practice
+/// - Maturity level : Experimental
+/// - Quick fix      : ✅
+///
+/// **Consider** replace `void Function(T value)` with [ValueChanged]
+/// which is defined in Flutter SDK.
+///
+/// **BAD:**
+/// ```dart
+/// final void Function(int value) callback;
+/// ```
+///
+/// **GOOD:**
+/// ```dart
+/// final ValueChanged<int> callback;
+/// ```
+class DefinedValueChangedType extends _DefinedValueCallbackType {
+  /// Create a new instance of [DefinedValueChangedType].
+  const DefinedValueChangedType() : super(_code);
+
+  static const _code = LintCode(
+    name: 'defined_value_changed_type',
+    problemMessage: '`ValueChanged<T>` type is defined in Flutter SDK.',
+    url: 'https://github.com/ronnnnn/nilts#defined_value_changed_type',
+  );
+
+  @override
+  List<Fix> getFixes() => [
+        _ReplaceWithValueChanged(),
+      ];
+}
+
+/// A class for `defined_value_setter_type` rule.
+///
+/// This rule checks defining `void Function(T value)` type.
+///
+/// - Target SDK     : Any versions nilts supports
+/// - Rule type      : Practice
+/// - Maturity level : Experimental
+/// - Quick fix      : ✅
+///
+/// **Consider** replace `void Function(T value)` with [ValueSetter]
+/// which is defined in Flutter SDK.
+///
+/// **BAD:**
+/// ```dart
+/// final void Function(int value) callback;
+/// ```
+///
+/// **GOOD:**
+/// ```dart
+/// final ValueSetter<int> callback;
+/// ```
+class DefinedValueSetterType extends _DefinedValueCallbackType {
+  /// Create a new instance of [DefinedValueSetterType].
+  const DefinedValueSetterType() : super(_code);
+
+  static const _code = LintCode(
+    name: 'defined_value_setter_type',
+    problemMessage: '`ValueSetter<T>` type is defined in Flutter SDK.',
+    url: 'https://github.com/ronnnnn/nilts#defined_value_setter_type',
+  );
+
+  @override
+  List<Fix> getFixes() => [
+        _ReplaceWithValueSetter(),
+      ];
+}
+
+class _ReplaceWithValueChanged extends _ReplaceWithValueCallbackType {
+  _ReplaceWithValueChanged()
+      : super(
+          'ValueChanged',
+          ChangePriority.replaceWithValueChanged,
+        );
+}
+
+class _ReplaceWithValueSetter extends _ReplaceWithValueCallbackType {
+  _ReplaceWithValueSetter()
+      : super(
+          'ValueSetter',
+          ChangePriority.replaceWithValueSetter,
+        );
+}
+
+class _DefinedValueCallbackType extends DartLintRule {
+  const _DefinedValueCallbackType(LintCode code)
+      : _lintCode = code,
+        super(code: code);
+
+  final LintCode _lintCode;
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addTypeAnnotation((node) {
+      final type = node.type;
+      // Do nothing if the type is not Function.
+      if (type is! FunctionType) return;
+
+      // Do nothing if Function doesn't have a parameter.
+      if (type.parameters.length != 1) return;
+
+      final param = type.parameters.first;
+      // Do nothing if the parameter is named or optional.
+      if (param.isNamed || param.isOptional) return;
+
+      // Do nothing if the return type is not void.
+      final returnType = type.returnType;
+      if (returnType is! VoidType) return;
+
+      reporter.reportErrorForNode(_lintCode, node);
+    });
+  }
+}
+
+class _ReplaceWithValueCallbackType extends DartFix {
+  _ReplaceWithValueCallbackType(
+    this._typeName,
+    this._changePriority,
+  );
+
+  final String _typeName;
+  final int _changePriority;
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ChangeReporter reporter,
+    CustomLintContext context,
+    AnalysisError analysisError,
+    List<AnalysisError> others,
+  ) {
+    context.registry.addTypeAnnotation((node) {
+      if (!node.sourceRange.intersects(analysisError.sourceRange)) return;
+
+      reporter
+          .createChangeBuilder(
+        message: 'Replace with $_typeName<T>',
+        priority: _changePriority,
+      )
+          .addDartFileEdit((builder) {
+        final paramTypeName = (node.type! as FunctionType)
+            .parameters
+            .first
+            .type
+            .element!
+            .displayName;
+
+        final delta = node.question != null ? -1 : 0;
+        builder.addSimpleReplacement(
+          node.sourceRange.getMoveEnd(delta),
+          '$_typeName<$paramTypeName>',
+        );
+      });
+    });
+  }
+}

--- a/packages/nilts/lib/src/lints/defined_value_callback_type.dart
+++ b/packages/nilts/lib/src/lints/defined_value_callback_type.dart
@@ -17,6 +17,7 @@ import 'package:nilts/src/change_priority.dart';
 ///
 /// **Consider** replace `void Function(T value)` with [ValueChanged]
 /// which is defined in Flutter SDK.
+/// If the value has been set, use [ValueSetter] instead.
 ///
 /// **BAD:**
 /// ```dart
@@ -27,6 +28,11 @@ import 'package:nilts/src/change_priority.dart';
 /// ```dart
 /// final ValueChanged<int> callback;
 /// ```
+///
+/// See also:
+///
+/// - [ValueChanged typedef - foundation library - Dart API](https://api.flutter.dev/flutter/foundation/ValueChanged.html)
+/// - [ValueSetter typedef - foundation library - Dart API](https://api.flutter.dev/flutter/foundation/ValueSetter.html)
 class DefinedValueChangedType extends _DefinedValueCallbackType {
   /// Create a new instance of [DefinedValueChangedType].
   const DefinedValueChangedType() : super(_code);
@@ -54,6 +60,7 @@ class DefinedValueChangedType extends _DefinedValueCallbackType {
 ///
 /// **Consider** replace `void Function(T value)` with [ValueSetter]
 /// which is defined in Flutter SDK.
+/// If the value has changed, use [ValueChanged] instead.
 ///
 /// **BAD:**
 /// ```dart
@@ -64,6 +71,11 @@ class DefinedValueChangedType extends _DefinedValueCallbackType {
 /// ```dart
 /// final ValueSetter<int> callback;
 /// ```
+///
+/// See also:
+///
+///   - [ValueSetter typedef - foundation library - Dart API](https://api.flutter.dev/flutter/foundation/ValueSetter.html)
+///   - [ValueChanged typedef - foundation library - Dart API](https://api.flutter.dev/flutter/foundation/ValueChanged.html)
 class DefinedValueSetterType extends _DefinedValueCallbackType {
   /// Create a new instance of [DefinedValueSetterType].
   const DefinedValueSetterType() : super(_code);

--- a/packages/nilts/lib/src/lints/defined_void_callback_type.dart
+++ b/packages/nilts/lib/src/lints/defined_void_callback_type.dart
@@ -27,6 +27,10 @@ import 'package:nilts/src/change_priority.dart';
 /// ```dart
 /// final VoidCallback callback;
 /// ```
+///
+/// See also:
+///
+/// - [VoidCallback typedef - dart:ui library - Dart API](https://api.flutter.dev/flutter/dart-ui/VoidCallback.html)
 class DefinedVoidCallbackType extends DartLintRule {
   /// Create a new instance of [DefinedVoidCallbackType].
   const DefinedVoidCallbackType() : super(code: _code);

--- a/packages/nilts_test/test/lints/defined_value_callback_type.dart
+++ b/packages/nilts_test/test/lints/defined_value_callback_type.dart
@@ -1,0 +1,103 @@
+// ignore_for_file: prefer_function_declarations_over_variables
+// ignore_for_file: type_init_formals
+// ignore_for_file: unused_element
+// ignore_for_file: defined_void_callback_type
+
+import 'package:flutter/material.dart';
+
+class MainButton extends StatelessWidget {
+  const MainButton(
+    void Function() this.onPressed,
+    // expect_lint: defined_value_changed_type, defined_value_setter_type
+    void Function(int) this.onParamPressed,
+    // expect_lint: defined_value_changed_type, defined_value_setter_type
+    void Function(int value) this.onNamedParamPressed,
+    void Function({int value}) this.onOptionalParamPressed,
+    void Function({required int value}) this.onRequiredParamPressed, {
+    void Function()? this.onNullablePressed,
+    // expect_lint: defined_value_changed_type, defined_value_setter_type
+    void Function(int)? this.onNullableParamPressed,
+    // expect_lint: defined_value_changed_type, defined_value_setter_type
+    void Function(int value)? this.onNullableNamedParamPressed,
+    int Function()? this.onNotVoidPressed,
+    super.key,
+  });
+
+  final void Function() onPressed;
+  // expect_lint: defined_value_changed_type, defined_value_setter_type
+  final void Function(int) onParamPressed;
+  // expect_lint: defined_value_changed_type, defined_value_setter_type
+  final void Function(int value) onNamedParamPressed;
+  final void Function({int value}) onOptionalParamPressed;
+  final void Function({required int value}) onRequiredParamPressed;
+  final void Function()? onNullablePressed;
+  // expect_lint: defined_value_changed_type, defined_value_setter_type
+  final void Function(int)? onNullableParamPressed;
+  // expect_lint: defined_value_changed_type, defined_value_setter_type
+  final void Function(int value)? onNullableNamedParamPressed;
+  final int Function()? onNotVoidPressed;
+
+  void _onPressed(
+    void Function() onPressed,
+    // expect_lint: defined_value_changed_type, defined_value_setter_type
+    void Function(int) onParamPressed,
+    // expect_lint: defined_value_changed_type, defined_value_setter_type
+    void Function(int value) onNamedParamPressed,
+    void Function({int? value}) onOptionalParamPressed,
+    void Function({required int value}) onRequiredParamPressed, {
+    void Function()? onNullablePressed,
+    // expect_lint: defined_value_changed_type, defined_value_setter_type
+    void Function(int)? onNullableParamPressed,
+    // expect_lint: defined_value_changed_type, defined_value_setter_type
+    void Function(int value)? onNullableNamedParamPressed,
+    int Function()? onNotVoidPressed,
+  }) {}
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton(
+      onPressed: () {
+        _onPressed(
+          () {},
+          (value) {},
+          (value) {},
+          ({value}) {},
+          ({required int value}) {},
+        );
+        onPressed();
+      },
+      child: const Text('Hello World!'),
+    );
+  }
+}
+
+final void Function() globalFunction = () {};
+// expect_lint: defined_value_changed_type, defined_value_setter_type
+final void Function(int) globalParamFunction = (value) {};
+// expect_lint: defined_value_changed_type, defined_value_setter_type
+final void Function(int value) globalNamedParamFunction = (value) {};
+final void Function({int? value}) globalOptionalParamFunction = ({value}) {};
+final void Function({required int value}) globalRequiredParamFunction =
+    ({required value}) {};
+const void Function()? globalNullableFunction = null;
+// expect_lint: defined_value_changed_type, defined_value_setter_type
+const void Function(int)? globalNullableParamFunction = null;
+// expect_lint: defined_value_changed_type, defined_value_setter_type
+const void Function(int value)? globalNullableNamedParamFunction = null;
+const int Function()? globalNotVoidFunction = null;
+
+void _globalFunction(
+  void Function() onPressed,
+  // expect_lint: defined_value_changed_type, defined_value_setter_type
+  void Function(int) onParamPressed,
+  // expect_lint: defined_value_changed_type, defined_value_setter_type
+  void Function(int value) onNamedParamPressed,
+  void Function({int? value}) onOptionalParamPressed,
+  void Function({required int value}) onRequiredParamPressed, {
+  void Function()? onNullablePressed,
+  // expect_lint: defined_value_changed_type, defined_value_setter_type
+  void Function(int)? onNullableParamPressed,
+  // expect_lint: defined_value_changed_type, defined_value_setter_type
+  void Function(int value)? onNullableNamedParamPressed,
+  int Function()? onNotVoidPressed,
+}) {}

--- a/packages/nilts_test/test/lints/defined_void_callback_type.dart
+++ b/packages/nilts_test/test/lints/defined_void_callback_type.dart
@@ -1,6 +1,8 @@
 // ignore_for_file: prefer_function_declarations_over_variables
 // ignore_for_file: type_init_formals
 // ignore_for_file: unused_element
+// ignore_for_file: defined_value_changed_type
+// ignore_for_file: defined_value_setter_type
 
 import 'package:flutter/material.dart';
 


### PR DESCRIPTION
## Overview

Checks `void Function(T value)` definitions.

<!-- Summarize what do you want add in this PR. -->

## Copilot Summary

<details><summary>summary</summary>
<p>

This pull request introduces new lint rules to the `nilts` package to check for the definition of `void Function(T value)` types and suggest replacements with `ValueChanged<T>` or `ValueSetter<T>` types defined in the Flutter SDK. The changes also include the addition of the corresponding test cases.

Lint rule additions:

* [`packages/nilts/lib/nilts.dart`](diffhunk://#diff-27ed6596f095f047c95c471364f6bcea88b264b422477770d0a541f7b21e94f5R3): Imported the new lint rules and added them to the list of lint rules in the `_NiltsLint` class. [[1]](diffhunk://#diff-27ed6596f095f047c95c471364f6bcea88b264b422477770d0a541f7b21e94f5R3) [[2]](diffhunk://#diff-27ed6596f095f047c95c471364f6bcea88b264b422477770d0a541f7b21e94f5R21-R22)
* [`packages/nilts/lib/src/change_priority.dart`](diffhunk://#diff-5a01b1144dc74e8c26aa7e101e08d538025702622784155761d2e678fde083f1R41-R46): Added priorities for the new lint rules.
* [`packages/nilts/lib/src/lints/defined_value_callback_type.dart`](diffhunk://#diff-dba01a848957ea024047247ab40653ca6fdbe88a02e570d6d43c338e0a70477cR1-R174): Defined the new lint rules `DefinedValueChangedType` and `DefinedValueSetterType`, which check for the definition of `void Function(T value)` types and suggest replacements with `ValueChanged<T>` or `ValueSetter<T>` types defined in the Flutter SDK. Also defined the corresponding fix classes `_ReplaceWithValueChanged` and `_ReplaceWithValueSetter`.

Test additions:

* [`packages/nilts_test/test/lints/defined_value_callback_type.dart`](diffhunk://#diff-6993552fc211645e2e3a04b4f3510e50edc2b2e88458126dd0038af5c62bd1dfR1-R103): Added test cases for the new lint rules.
* [`packages/nilts_test/test/lints/defined_void_callback_type.dart`](diffhunk://#diff-83eb8115d4bad6443edc07ad7e2cba4049dd9b4ce904daa73f8396366a9b078fR4-R5): Ignored the new lint rules in the test cases for the `defined_void_callback_type` rule.

</p>
</details> 

## Feature type

<!-- Select which type of feature you want to add. -->

- [x] Lint Rule
- [x] Quick fix
- [ ] Assist
- [ ] Other (Update docs, Configure CI, etc...)
