### PR TITLE
feat: defined_value_getter_type

### DIFF
--- a/examples/nilts_example/pubspec.lock
+++ b/examples/nilts_example/pubspec.lock
@@ -241,7 +241,7 @@ packages:
       path: "../../packages/nilts"
       relative: true
     source: path
-    version: "0.9.0+1"
+    version: "0.10.0"
   package_config:
     dependency: transitive
     description:

--- a/packages/nilts/README.md
+++ b/packages/nilts/README.md
@@ -113,8 +113,8 @@ Some of lint rules support quick fixes on IDE.
 - Maturity level : Experimental
 - Quick fix      : ✅
 
-**Consider** replace `void Function(T value)` with [ValueChanged] which is defined in Flutter SDK.  
-If the value has been set, use [ValueSetter] instead.
+**Consider** replace `void Function(T value)` with `ValueChanged` which is defined in Flutter SDK.  
+If the value has been set, use `ValueSetter` instead.
 
 **BAD:**
 ```dart
@@ -142,7 +142,7 @@ See also:
 - Maturity level : Experimental
 - Quick fix      : ✅
 
-**Consider** replace `T Function()` with [ValueGetter] which is defined in Flutter SDK.
+**Consider** replace `T Function()` with `ValueGetter` which is defined in Flutter SDK.
 
 **BAD:**
 ```dart
@@ -169,8 +169,8 @@ See also:
 - Maturity level : Experimental
 - Quick fix      : ✅
 
-**Consider** replace `void Function(T value)` with [ValueSetter] which is defined in Flutter SDK.  
-If the value has changed, use [ValueChanged] instead.
+**Consider** replace `void Function(T value)` with `ValueSetter` which is defined in Flutter SDK.  
+If the value has changed, use `ValueChanged` instead.
 
 **BAD:**
 ```dart
@@ -228,7 +228,7 @@ See also:
 - Maturity level : Experimental
 - Quick fix      : ✅
 
-**Consider** using `Text.rich` or adding `textScaler` or `textScaleFactor` (deprecated on Flutter 3.16.0 and above) argument to [RichText] constructor to make the text size responsive for user setting.  
+**Consider** using `Text.rich` or adding `textScaler` or `textScaleFactor` (deprecated on Flutter 3.16.0 and above) argument to `RichText` constructor to make the text size responsive for user setting.  
 
 **BAD:**
 ```dart

--- a/packages/nilts/README.md
+++ b/packages/nilts/README.md
@@ -93,6 +93,7 @@ Some of lint rules support quick fixes on IDE.
 | Rule name                                                                           | Overview                                                                       |           Target SDK           | Rule type | Maturity level | Quick fix |
 |:------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------|:------------------------------:| :-------: |:--------------:|:---------:|
 | [defined\_value\_changed\_type](#defined_value_changed_type)                        | Checks `void Function(T value)` definitions.                                   |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️     |
+| [defined\_value\_getter\_type](#defined_value_getter_type)                          | Checks `T Function()` definitions.                                             |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️     |
 | [defined\_value\_setter\_type](#defined_value_setter_type)                          | Checks `void Function(T value)` definitions.                                   |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️     |
 | [defined\_void\_callback\_type](#defined_void_callback_type)                        | Checks `void Function()` definitions.                                          |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️     |
 | [fixed\_text\_scale\_rich\_text](#fixed_text_scale_rich_text)                       | Checks usage of `textScaler` or `textScaleFactor` in `RichText` constructor.   |  Any versions nilts supports   | Practice  |  Experimental  |    ✅️     |
@@ -129,6 +130,33 @@ See also:
 
 - [ValueChanged typedef - foundation library - Dart API](https://api.flutter.dev/flutter/foundation/ValueChanged.html)
 - [ValueSetter typedef - foundation library - Dart API](https://api.flutter.dev/flutter/foundation/ValueSetter.html)
+
+</details>
+
+#### defined_value_getter_type
+
+<details>
+
+- Target SDK     : Any versions nilts supports
+- Rule type      : Practice
+- Maturity level : Experimental
+- Quick fix      : ✅
+
+**Consider** replace `T Function()` with [ValueGetter] which is defined in Flutter SDK.
+
+**BAD:**
+```dart
+final int Function() callback;
+```
+
+**GOOD:**
+```dart
+final ValueGetter<int> callback;
+```
+
+See also:
+
+- [ValueGetter typedef - foundation library - Dart API](https://api.flutter.dev/flutter/foundation/ValueGetter.html)
 
 </details>
 

--- a/packages/nilts/lib/nilts.dart
+++ b/packages/nilts/lib/nilts.dart
@@ -1,6 +1,7 @@
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:nilts/src/dart_version.dart';
 import 'package:nilts/src/lints/defined_value_callback_type.dart';
+import 'package:nilts/src/lints/defined_value_getter_type.dart';
 import 'package:nilts/src/lints/defined_void_callback_type.dart';
 import 'package:nilts/src/lints/fixed_text_scale_rich_text.dart';
 import 'package:nilts/src/lints/flaky_tests_with_set_up_all.dart';
@@ -19,6 +20,7 @@ class _NiltsLint extends PluginBase {
   @override
   List<LintRule> getLintRules(CustomLintConfigs configs) => [
         const DefinedValueChangedType(),
+        const DefinedValueGetterType(),
         const DefinedValueSetterType(),
         const DefinedVoidCallbackType(),
         if (_dartVersion >= const DartVersion(major: 3, minor: 2, patch: 0))

--- a/packages/nilts/lib/src/change_priority.dart
+++ b/packages/nilts/lib/src/change_priority.dart
@@ -41,6 +41,9 @@ class ChangePriority {
   /// The priority for [_ReplaceWithValueChanged].
   static const int replaceWithValueChanged = 100;
 
+  /// The priority for [_ReplaceWithValueGetter].
+  static const int replaceWithValueGetter = 100;
+
   /// The priority for [_ReplaceWithValueSetter].
   static const int replaceWithValueSetter = 100;
 

--- a/packages/nilts/lib/src/lints/defined_value_getter_type.dart
+++ b/packages/nilts/lib/src/lints/defined_value_getter_type.dart
@@ -1,0 +1,103 @@
+// ignore_for_file: comment_references
+
+import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:nilts/src/change_priority.dart';
+
+/// A class for `defined_value_getter_type` rule.
+///
+/// This rule checks defining `T Function()` type.
+///
+/// - Target SDK     : Any versions nilts supports
+/// - Rule type      : Practice
+/// - Maturity level : Experimental
+/// - Quick fix      : ✅
+///
+/// **Consider** replace `T Function()` with [ValueGetter] which is defined
+/// in Flutter SDK.
+///
+/// **BAD:**
+/// ```dart
+/// final int Function() callback;
+/// ```
+///
+/// **GOOD:**
+/// ```dart
+/// final ValueGetter<int> callback;
+/// ```
+///
+/// See also:
+///
+/// - [ValueGetter typedef - foundation library - Dart API](https://api.flutter.dev/flutter/foundation/ValueGetter.html)
+class DefinedValueGetterType extends DartLintRule {
+  /// Create a new instance of [DefinedValueGetterType].
+  const DefinedValueGetterType() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'defined_value_getter_type',
+    problemMessage: '`ValueGetter<T>` type is defined in Flutter SDK.',
+    url: 'https://github.com/ronnnnn/nilts#defined_value_getter_type',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addTypeAnnotation((node) {
+      final type = node.type;
+      // Do nothing if the type is not Function.
+      if (type is! FunctionType) return;
+
+      // Do nothing if Function has parameters.
+      if (type.parameters.isNotEmpty) return;
+
+      // Do nothing if the return type is not void.
+      final returnType = type.returnType;
+      if (returnType is VoidType ||
+          returnType is InvalidType ||
+          returnType is NeverType) return;
+
+      reporter.reportErrorForNode(_code, node);
+    });
+  }
+
+  @override
+  List<Fix> getFixes() => [
+        _ReplaceWithValueGetter(),
+      ];
+}
+
+class _ReplaceWithValueGetter extends DartFix {
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ChangeReporter reporter,
+    CustomLintContext context,
+    AnalysisError analysisError,
+    List<AnalysisError> others,
+  ) {
+    context.registry.addTypeAnnotation((node) {
+      if (!node.sourceRange.intersects(analysisError.sourceRange)) return;
+
+      reporter
+          .createChangeBuilder(
+        message: 'Replace with ValueGetter<T>',
+        priority: ChangePriority.replaceWithValueGetter,
+      )
+          .addDartFileEdit((builder) {
+        final returnTypeName =
+            (node.type! as FunctionType).returnType.element!.displayName;
+
+        final delta = node.question != null ? -1 : 0;
+        builder.addSimpleReplacement(
+          node.sourceRange.getMoveEnd(delta),
+          'ValueGetter<$returnTypeName>',
+        );
+      });
+    });
+  }
+}

--- a/packages/nilts_test/pubspec.lock
+++ b/packages/nilts_test/pubspec.lock
@@ -241,7 +241,7 @@ packages:
       path: "../nilts"
       relative: true
     source: path
-    version: "0.9.0+1"
+    version: "0.10.0"
   package_config:
     dependency: transitive
     description:

--- a/packages/nilts_test/test/lints/defined_value_callback_type.dart
+++ b/packages/nilts_test/test/lints/defined_value_callback_type.dart
@@ -2,6 +2,7 @@
 // ignore_for_file: type_init_formals
 // ignore_for_file: unused_element
 // ignore_for_file: defined_void_callback_type
+// ignore_for_file: defined_value_getter_type
 
 import 'package:flutter/material.dart';
 

--- a/packages/nilts_test/test/lints/defined_value_getter_type.dart
+++ b/packages/nilts_test/test/lints/defined_value_getter_type.dart
@@ -3,42 +3,48 @@
 // ignore_for_file: unused_element
 // ignore_for_file: defined_value_changed_type
 // ignore_for_file: defined_value_setter_type
-// ignore_for_file: defined_value_getter_type
+// ignore_for_file: defined_void_callback_type
 
 import 'package:flutter/material.dart';
 
 class MainButton extends StatelessWidget {
   const MainButton(
-    // expect_lint: defined_void_callback_type
-    void Function() this.onPressed, {
-    // expect_lint: defined_void_callback_type
+    void Function() this.onPressed,
+    // expect_lint: defined_value_getter_type
+    int Function() this.onReturnPressed, {
     void Function()? this.onNullablePressed,
     void Function(int)? this.onParamPressed,
-    int Function()? this.onNotVoidPressed,
+    // expect_lint: defined_value_getter_type
+    int Function()? this.onNullableReturnPressed,
     super.key,
   });
 
-  // expect_lint: defined_void_callback_type
   final void Function() onPressed;
-  // expect_lint: defined_void_callback_type
+  // expect_lint: defined_value_getter_type
+  final int Function() onReturnPressed;
   final void Function()? onNullablePressed;
   final void Function(int)? onParamPressed;
-  final int Function()? onNotVoidPressed;
+  // expect_lint: defined_value_getter_type
+  final int Function()? onNullableReturnPressed;
 
   void _onPressed(
-    // expect_lint: defined_void_callback_type
-    void Function() onPressed, {
-    // expect_lint: defined_void_callback_type
+    void Function() onPressed,
+    // expect_lint: defined_value_getter_type
+    int Function() onReturnPressed, {
     void Function()? onNullablePressed,
     void Function(int)? onParamPressed,
-    int Function()? onNotVoidPressed,
+    // expect_lint: defined_value_getter_type
+    int Function()? onNullableReturnPressed,
   }) {}
 
   @override
   Widget build(BuildContext context) {
     return FilledButton(
       onPressed: () {
-        _onPressed(() {});
+        _onPressed(
+          () {},
+          () => 0,
+        );
         onPressed();
       },
       child: const Text('Hello World!'),
@@ -46,18 +52,20 @@ class MainButton extends StatelessWidget {
   }
 }
 
-// expect_lint: defined_void_callback_type
 final void Function() globalFunction = () {};
-// expect_lint: defined_void_callback_type
+// expect_lint: defined_value_getter_type
+final int Function() globalReturnFunction = () => 0;
 const void Function()? globalNullableFunction = null;
 const void Function(int)? globalParamFunction = null;
-const int Function()? globalNotVoidFunction = null;
+// expect_lint: defined_value_getter_type
+const int Function()? globalNullableReturnFunction = null;
 
 void _globalFunction(
-  // expect_lint: defined_void_callback_type
-  void Function() onPressed, {
-  // expect_lint: defined_void_callback_type
+  void Function() onPressed,
+  // expect_lint: defined_value_getter_type
+  int Function() onReturnPressed, {
   void Function()? onNullablePressed,
   void Function(int)? onParamPressed,
-  int Function()? onNotVoidPressed,
+  // expect_lint: defined_value_getter_type
+  int Function()? onNullableReturnPressed,
 }) {}


### PR DESCRIPTION
## Overview

Checks `T Function()` definitions.

<!-- Summarize what do you want add in this PR. -->

## Copilot Summary

<details><summary>Details</summary>
<p>

This pull request primarily introduces a new lint rule `defined_value_getter_type` to the `nilts` package. This rule checks for the use of `T Function()` definitions and suggests replacing them with `ValueGetter` from the Flutter SDK. The rule is added to the lint rules list in `nilts.dart` and its priority is defined in `change_priority.dart`. The `README.md` is updated to include this new rule in the lint rules table and details about it. Additionally, some existing lint rules descriptions in `README.md` are modified to enclose certain code identifiers in backticks for better readability. The test files are updated to include tests for this new rule and to ignore this rule where necessary.

New lint rule addition:

* [`packages/nilts/lib/src/lints/defined_value_getter_type.dart`](diffhunk://#diff-c52af51b5932686cd3e8f93c68fc2375f4e6a22b0c932c184d70965d6416edd0R1-R103): Added a new lint rule `defined_value_getter_type` that checks for `T Function()` definitions and suggests replacing them with `ValueGetter` from the Flutter SDK.

Lint rules list and priority updates:

* [`packages/nilts/lib/nilts.dart`](diffhunk://#diff-27ed6596f095f047c95c471364f6bcea88b264b422477770d0a541f7b21e94f5R4): Added the new lint rule to the lint rules list. [[1]](diffhunk://#diff-27ed6596f095f047c95c471364f6bcea88b264b422477770d0a541f7b21e94f5R4) [[2]](diffhunk://#diff-27ed6596f095f047c95c471364f6bcea88b264b422477770d0a541f7b21e94f5R23)
* [`packages/nilts/lib/src/change_priority.dart`](diffhunk://#diff-5a01b1144dc74e8c26aa7e101e08d538025702622784155761d2e678fde083f1R44-R46): Defined the priority for the new lint rule.

README updates:

* [`packages/nilts/README.md`](diffhunk://#diff-ff9db041b5e3a0050d7c57c1684a5389e9a511650e41d5d959655a4ef2efce4dR96): Updated the lint rules table to include the new rule and modified some existing lint rules descriptions to enclose certain code identifiers in backticks. [[1]](diffhunk://#diff-ff9db041b5e3a0050d7c57c1684a5389e9a511650e41d5d959655a4ef2efce4dR96) [[2]](diffhunk://#diff-ff9db041b5e3a0050d7c57c1684a5389e9a511650e41d5d959655a4ef2efce4dL115-R117) [[3]](diffhunk://#diff-ff9db041b5e3a0050d7c57c1684a5389e9a511650e41d5d959655a4ef2efce4dR136-R162) [[4]](diffhunk://#diff-ff9db041b5e3a0050d7c57c1684a5389e9a511650e41d5d959655a4ef2efce4dL144-R173) [[5]](diffhunk://#diff-ff9db041b5e3a0050d7c57c1684a5389e9a511650e41d5d959655a4ef2efce4dL203-R231)

Test files updates:

* [`packages/nilts_test/test/lints/defined_value_callback_type.dart`](diffhunk://#diff-6993552fc211645e2e3a04b4f3510e50edc2b2e88458126dd0038af5c62bd1dfR5): Updated to ignore the new lint rule.
* [`packages/nilts_test/test/lints/defined_value_getter_type.dart`](diffhunk://#diff-2578ba7e81d4f8d2a7605f404c69317a38a46c14cdac00414607a3ec22715926R1-R71): Added tests for the new lint rule.
* [`packages/nilts_test/test/lints/defined_void_callback_type.dart`](diffhunk://#diff-83eb8115d4bad6443edc07ad7e2cba4049dd9b4ce904daa73f8396366a9b078fR6): Updated to ignore the new lint rule.

</p>
</details> 

## Feature type

<!-- Select which type of feature you want to add. -->

- [x] Lint Rule
- [x] Quick fix
- [ ] Assist
- [ ] Other (Update docs, Configure CI, etc...)