### PR TITLE
fix: ignore defined_value_getter_type if return Future

### DIFF
--- a/packages/nilts/lib/src/lints/defined_value_getter_type.dart
+++ b/packages/nilts/lib/src/lints/defined_value_getter_type.dart
@@ -59,7 +59,8 @@ class DefinedValueGetterType extends DartLintRule {
       final returnType = type.returnType;
       if (returnType is VoidType ||
           returnType is InvalidType ||
-          returnType is NeverType) return;
+          returnType is NeverType ||
+          returnType.isDartAsyncFuture) return;
 
       reporter.reportErrorForNode(_code, node);
     });

--- a/packages/nilts_test/test/lints/defined_value_getter_type.dart
+++ b/packages/nilts_test/test/lints/defined_value_getter_type.dart
@@ -11,30 +11,36 @@ class MainButton extends StatelessWidget {
   const MainButton(
     void Function() this.onPressed,
     // expect_lint: defined_value_getter_type
-    int Function() this.onReturnPressed, {
+    int Function() this.onReturnPressed,
+    Future<int> Function() this.onFutureReturnPressed, {
     void Function()? this.onNullablePressed,
     void Function(int)? this.onParamPressed,
     // expect_lint: defined_value_getter_type
     int Function()? this.onNullableReturnPressed,
+    Future<int> Function()? this.onNullableFutureReturnPressed,
     super.key,
   });
 
   final void Function() onPressed;
   // expect_lint: defined_value_getter_type
   final int Function() onReturnPressed;
+  final Future<int> Function() onFutureReturnPressed;
   final void Function()? onNullablePressed;
   final void Function(int)? onParamPressed;
   // expect_lint: defined_value_getter_type
   final int Function()? onNullableReturnPressed;
+  final Future<int> Function()? onNullableFutureReturnPressed;
 
   void _onPressed(
     void Function() onPressed,
     // expect_lint: defined_value_getter_type
-    int Function() onReturnPressed, {
+    int Function() onReturnPressed,
+    Future<int> Function() onFutureReturnPressed, {
     void Function()? onNullablePressed,
     void Function(int)? onParamPressed,
     // expect_lint: defined_value_getter_type
     int Function()? onNullableReturnPressed,
+    Future<int> Function()? onNullableFutureReturnPressed,
   }) {}
 
   @override
@@ -44,6 +50,7 @@ class MainButton extends StatelessWidget {
         _onPressed(
           () {},
           () => 0,
+          () async => 0,
         );
         onPressed();
       },
@@ -55,17 +62,21 @@ class MainButton extends StatelessWidget {
 final void Function() globalFunction = () {};
 // expect_lint: defined_value_getter_type
 final int Function() globalReturnFunction = () => 0;
+final Future<int> Function() globalFutureReturnFunction = () async => 0;
 const void Function()? globalNullableFunction = null;
 const void Function(int)? globalParamFunction = null;
 // expect_lint: defined_value_getter_type
 const int Function()? globalNullableReturnFunction = null;
+const Future<int> Function()? globalNullableFutureReturnFunction = null;
 
 void _globalFunction(
   void Function() onPressed,
   // expect_lint: defined_value_getter_type
-  int Function() onReturnPressed, {
+  int Function() onReturnPressed,
+  Future<int> Function() onFutureReturnPressed, {
   void Function()? onNullablePressed,
   void Function(int)? onParamPressed,
   // expect_lint: defined_value_getter_type
   int Function()? onNullableReturnPressed,
+  Future<int> Function()? onNullableFutureReturnPressed,
 }) {}


### PR DESCRIPTION
## Overview

Ignore `defined_value_getter_type` lint if return Future type.

<!-- Summarize what do you want add in this PR. -->

## Copilot Summary

<details><summary>Details</summary>
<p>

This pull request primarily addresses two files in the `nilts` and `nilts_test` packages, introducing support for asynchronous functions in the `DefinedValueGetterType` lint rule and updating the `MainButton` class to align with these changes. The most significant changes are the addition of a check for `Future` return types in the lint rule and the introduction of `Future` return type functions in the `MainButton` class.

Lint Rule Changes:
* [`packages/nilts/lib/src/lints/defined_value_getter_type.dart`](diffhunk://#diff-c52af51b5932686cd3e8f93c68fc2375f4e6a22b0c932c184d70965d6416edd0L62-R63): Updated the `DefinedValueGetterType` lint rule to include a check for Dart's `Future` return type. This change allows the lint rule to correctly handle asynchronous functions.

MainButton Class Changes:
* [`packages/nilts_test/test/lints/defined_value_getter_type.dart`](diffhunk://#diff-2578ba7e81d4f8d2a7605f404c69317a38a46c14cdac00414607a3ec22715926L14-R43): Added `Future<int> Function()` as a possible type for `onReturnPressed`, `onFutureReturnPressed`, `onNullableReturnPressed`, and `onNullableFutureReturnPressed` in the `MainButton` class. This change ensures that the class can handle asynchronous functions that return an `int`. [[1]](diffhunk://#diff-2578ba7e81d4f8d2a7605f404c69317a38a46c14cdac00414607a3ec22715926L14-R43) [[2]](diffhunk://#diff-2578ba7e81d4f8d2a7605f404c69317a38a46c14cdac00414607a3ec22715926R53) [[3]](diffhunk://#diff-2578ba7e81d4f8d2a7605f404c69317a38a46c14cdac00414607a3ec22715926R65-R81)

</p>
</details> 

## Feature type

<!-- Select which type of feature you want to add. -->

- [x] Lint Rule
- [ ] Quick fix
- [ ] Assist
- [ ] Other (Update docs, Configure CI, etc...)