### PR TITLE
fix: Quick fix for defined callbacks lint rules which have a param or return type

### DIFF
--- a/packages/nilts/lib/src/lints/defined_async_value_getter_type.dart
+++ b/packages/nilts/lib/src/lints/defined_async_value_getter_type.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: comment_references
 
+import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/error/error.dart' as analyzer;
 import 'package:analyzer/error/listener.dart';
@@ -99,13 +100,17 @@ class _ReplaceWithAsyncValueGetter extends DartFix {
       )
           .addDartFileEdit((builder) {
         final returnType = (node.type! as FunctionType).returnType;
-        final returnTypeArgumentName =
-            (returnType as InterfaceType).typeArguments.first.element!.name;
+        final returnTypeArgument =
+            (returnType as InterfaceType).typeArguments.first;
+        final isReturnTypeArgumentNullable =
+            returnTypeArgument.nullabilitySuffix == NullabilitySuffix.question;
+        final returnTypeArgumentName = returnTypeArgument.element!.name;
 
         final delta = node.question != null ? -1 : 0;
+        final suffix = isReturnTypeArgumentNullable ? '?' : '';
         builder.addSimpleReplacement(
           node.sourceRange.getMoveEnd(delta),
-          'AsyncValueGetter<$returnTypeArgumentName>',
+          'AsyncValueGetter<$returnTypeArgumentName$suffix>',
         );
       });
     });

--- a/packages/nilts/lib/src/lints/defined_async_value_getter_type.dart
+++ b/packages/nilts/lib/src/lints/defined_async_value_getter_type.dart
@@ -90,6 +90,7 @@ class _ReplaceWithAsyncValueGetter extends DartFix {
   ) {
     context.registry.addTypeAnnotation((node) {
       if (!node.sourceRange.intersects(analysisError.sourceRange)) return;
+      if (node.type is! FunctionType) return;
 
       reporter
           .createChangeBuilder(

--- a/packages/nilts/lib/src/lints/defined_async_value_setter_type.dart
+++ b/packages/nilts/lib/src/lints/defined_async_value_setter_type.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: comment_references
 
+import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/error/error.dart' as analyzer;
 import 'package:analyzer/error/listener.dart';
@@ -99,17 +100,16 @@ class _ReplaceWithAsyncValueSetter extends DartFix {
         priority: ChangePriority.replaceWithAsyncValueSetter,
       )
           .addDartFileEdit((builder) {
-        final paramTypeName = (node.type! as FunctionType)
-            .parameters
-            .first
-            .type
-            .element!
-            .displayName;
+        final paramType = (node.type! as FunctionType).parameters.first.type;
+        final isParamTypeNullable =
+            paramType.nullabilitySuffix == NullabilitySuffix.question;
+        final paramTypeName = paramType.element!.displayName;
 
         final delta = node.question != null ? -1 : 0;
+        final suffix = isParamTypeNullable ? '?' : '';
         builder.addSimpleReplacement(
           node.sourceRange.getMoveEnd(delta),
-          'AsyncValueSetter<$paramTypeName>',
+          'AsyncValueSetter<$paramTypeName$suffix>',
         );
       });
     });

--- a/packages/nilts/lib/src/lints/defined_async_value_setter_type.dart
+++ b/packages/nilts/lib/src/lints/defined_async_value_setter_type.dart
@@ -91,6 +91,7 @@ class _ReplaceWithAsyncValueSetter extends DartFix {
   ) {
     context.registry.addTypeAnnotation((node) {
       if (!node.sourceRange.intersects(analysisError.sourceRange)) return;
+      if (node.type is! FunctionType) return;
 
       reporter
           .createChangeBuilder(

--- a/packages/nilts/lib/src/lints/defined_value_callback_type.dart
+++ b/packages/nilts/lib/src/lints/defined_value_callback_type.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: comment_references
 
+import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/error/error.dart' as analyzer;
 import 'package:analyzer/error/listener.dart';
@@ -173,17 +174,16 @@ class _ReplaceWithValueCallbackType extends DartFix {
         priority: _changePriority,
       )
           .addDartFileEdit((builder) {
-        final paramTypeName = (node.type! as FunctionType)
-            .parameters
-            .first
-            .type
-            .element!
-            .displayName;
+        final paramType = (node.type! as FunctionType).parameters.first.type;
+        final isSuffixNullable =
+            paramType.nullabilitySuffix == NullabilitySuffix.question;
+        final paramTypeName = paramType.element!.displayName;
 
         final delta = node.question != null ? -1 : 0;
+        final suffix = isSuffixNullable ? '?' : '';
         builder.addSimpleReplacement(
           node.sourceRange.getMoveEnd(delta),
-          '$_typeName<$paramTypeName>',
+          '$_typeName<$paramTypeName$suffix>',
         );
       });
     });

--- a/packages/nilts/lib/src/lints/defined_value_callback_type.dart
+++ b/packages/nilts/lib/src/lints/defined_value_callback_type.dart
@@ -165,6 +165,7 @@ class _ReplaceWithValueCallbackType extends DartFix {
   ) {
     context.registry.addTypeAnnotation((node) {
       if (!node.sourceRange.intersects(analysisError.sourceRange)) return;
+      if (node.type is! FunctionType) return;
 
       reporter
           .createChangeBuilder(

--- a/packages/nilts/lib/src/lints/defined_value_getter_type.dart
+++ b/packages/nilts/lib/src/lints/defined_value_getter_type.dart
@@ -87,6 +87,7 @@ class _ReplaceWithValueGetter extends DartFix {
   ) {
     context.registry.addTypeAnnotation((node) {
       if (!node.sourceRange.intersects(analysisError.sourceRange)) return;
+      if (node.type is! FunctionType) return;
 
       reporter
           .createChangeBuilder(

--- a/packages/nilts/lib/src/lints/defined_value_getter_type.dart
+++ b/packages/nilts/lib/src/lints/defined_value_getter_type.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: comment_references
 
+import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/error/error.dart' as analyzer;
 import 'package:analyzer/error/listener.dart';
@@ -95,13 +96,16 @@ class _ReplaceWithValueGetter extends DartFix {
         priority: ChangePriority.replaceWithValueGetter,
       )
           .addDartFileEdit((builder) {
-        final returnTypeName =
-            (node.type! as FunctionType).returnType.element!.displayName;
+        final returnType = (node.type! as FunctionType).returnType;
+        final isSuffixNullable =
+            returnType.nullabilitySuffix == NullabilitySuffix.question;
+        final returnTypeName = returnType.element!.displayName;
 
         final delta = node.question != null ? -1 : 0;
+        final suffix = isSuffixNullable ? '?' : '';
         builder.addSimpleReplacement(
           node.sourceRange.getMoveEnd(delta),
-          'ValueGetter<$returnTypeName>',
+          'ValueGetter<$returnTypeName$suffix>',
         );
       });
     });

--- a/packages/nilts_test/test/lints/defined_async_value_getter_type.dart
+++ b/packages/nilts_test/test/lints/defined_async_value_getter_type.dart
@@ -16,6 +16,8 @@ class MainButton extends StatelessWidget {
     AsyncValueGetter<int> this.onAliasPressed,
     // expect_lint: defined_async_value_getter_type
     Future<int> Function() this.onFutureReturnPressed,
+    // expect_lint: defined_async_value_getter_type
+    Future<int?> Function() this.onFutureNullableReturnPressed,
     int Function() this.onReturnPressed, {
     Future<void> Function()? this.onNullablePressed,
     Future<void> Function(int)? this.onParamPressed,
@@ -27,11 +29,16 @@ class MainButton extends StatelessWidget {
 
   final Future<void> Function() onPressed;
   final AsyncValueGetter<int> onAliasPressed;
+
   // expect_lint: defined_async_value_getter_type
   final Future<int> Function() onFutureReturnPressed;
+
+  // expect_lint: defined_async_value_getter_type
+  final Future<int?> Function() onFutureNullableReturnPressed;
   final int Function() onReturnPressed;
   final Future<void> Function()? onNullablePressed;
   final Future<void> Function(int)? onParamPressed;
+
   // expect_lint: defined_async_value_getter_type
   final Future<int> Function()? onNullableFutureReturnPressed;
   final int Function()? onNullableReturnPressed;

--- a/packages/nilts_test/test/lints/defined_async_value_setter_type.dart
+++ b/packages/nilts_test/test/lints/defined_async_value_setter_type.dart
@@ -14,7 +14,11 @@ class MainButton extends StatelessWidget {
     // expect_lint: defined_async_value_setter_type
     Future<void> Function(int) this.onParamPressed,
     // expect_lint: defined_async_value_setter_type
+    Future<void> Function(int?) this.onParamNullablePressed,
+    // expect_lint: defined_async_value_setter_type
     Future<void> Function(int value) this.onNamedParamPressed,
+    // expect_lint: defined_async_value_setter_type
+    Future<void> Function(int? value) this.onNamedParamNullablePressed,
     Future<void> Function({int value}) this.onOptionalParamPressed,
     Future<void> Function({required int value}) this.onRequiredParamPressed, {
     Future<void> Function()? this.onNullablePressed,
@@ -33,7 +37,13 @@ class MainButton extends StatelessWidget {
   final Future<void> Function(int) onParamPressed;
 
   // expect_lint: defined_async_value_setter_type
+  final Future<void> Function(int?) onParamNullablePressed;
+
+  // expect_lint: defined_async_value_setter_type
   final Future<void> Function(int value) onNamedParamPressed;
+
+  // expect_lint: defined_async_value_setter_type
+  final Future<void> Function(int? value) onNamedParamNullablePressed;
   final Future<void> Function({int value}) onOptionalParamPressed;
   final Future<void> Function({required int value}) onRequiredParamPressed;
   final Future<void> Function()? onNullablePressed;

--- a/packages/nilts_test/test/lints/defined_value_callback_type.dart
+++ b/packages/nilts_test/test/lints/defined_value_callback_type.dart
@@ -14,7 +14,11 @@ class MainButton extends StatelessWidget {
     // expect_lint: defined_value_changed_type, defined_value_setter_type
     void Function(int) this.onParamPressed,
     // expect_lint: defined_value_changed_type, defined_value_setter_type
+    void Function(int?) this.onParamNullablePressed,
+    // expect_lint: defined_value_changed_type, defined_value_setter_type
     void Function(int value) this.onNamedParamPressed,
+    // expect_lint: defined_value_changed_type, defined_value_setter_type
+    void Function(int? value) this.onNamedParamNullablePressed,
     void Function({int value}) this.onOptionalParamPressed,
     void Function({required int value}) this.onRequiredParamPressed, {
     void Function()? this.onNullablePressed,
@@ -32,7 +36,11 @@ class MainButton extends StatelessWidget {
   // expect_lint: defined_value_changed_type, defined_value_setter_type
   final void Function(int) onParamPressed;
   // expect_lint: defined_value_changed_type, defined_value_setter_type
+  final void Function(int?) onParamNullablePressed;
+  // expect_lint: defined_value_changed_type, defined_value_setter_type
   final void Function(int value) onNamedParamPressed;
+  // expect_lint: defined_value_changed_type, defined_value_setter_type
+  final void Function(int? value) onNamedParamNullablePressed;
   final void Function({int value}) onOptionalParamPressed;
   final void Function({required int value}) onRequiredParamPressed;
   final void Function()? onNullablePressed;

--- a/packages/nilts_test/test/lints/defined_value_getter_type.dart
+++ b/packages/nilts_test/test/lints/defined_value_getter_type.dart
@@ -14,6 +14,8 @@ class MainButton extends StatelessWidget {
     ValueGetter<int> this.onAliasPressed,
     // expect_lint: defined_value_getter_type
     int Function() this.onReturnPressed,
+    // expect_lint: defined_value_getter_type
+    int? Function() this.onReturnNullablePressed,
     Future<int> Function() this.onFutureReturnPressed, {
     void Function()? this.onNullablePressed,
     void Function(int)? this.onParamPressed,
@@ -27,6 +29,8 @@ class MainButton extends StatelessWidget {
   final ValueGetter<int> onAliasPressed;
   // expect_lint: defined_value_getter_type
   final int Function() onReturnPressed;
+  // expect_lint: defined_value_getter_type
+  final int? Function() onReturnNullablePressed;
   final Future<int> Function() onFutureReturnPressed;
   final void Function()? onNullablePressed;
   final void Function(int)? onParamPressed;


### PR DESCRIPTION
## Overview

Fix issues with using quick fixes for defined callback lint rules. 

- quick fixes are not showed
- support nullable param or return type

<!-- Summarize what do you want add in this PR. -->

## Feature type

<!-- Select which type of feature you want to add. -->

- [ ] Lint Rule
- [x] Quick fix
- [ ] Assist
- [ ] Other (Update docs, Configure CI, etc...)