### PR TITLE
build: use ubuntu-24.04-arm image for linux runner

### DIFF
--- a/.github/workflows/auto-asign.yml
+++ b/.github/workflows/auto-asign.yml
@@ -8,7 +8,7 @@ jobs:
   assign:
     if: |
       github.event.pull_request.user.type == 'User'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -22,7 +22,7 @@ jobs:
         run: melos lint
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -33,7 +33,7 @@ jobs:
         run: melos test
 
   build_example_android:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - id: app-token
         uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3


### PR DESCRIPTION
## Overview

<!-- Summarize what do you want add in this PR. -->

- use ubuntu-24.04-arm image for linux runner
  - https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

## Feature type

<!-- Select which type of feature you want to add. -->

- [ ] Lint Rule
- [ ] Quick fix
- [ ] Assist
- [x] Other (Update docs, Configure CI, etc...)