### PR TITLE
build: add Takumi Guard setup step to setup-bun action

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -7,6 +7,9 @@ runs:
     - name: Setup Bun
       uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
 
+    - name: Setup Takumi Guard
+      uses: flatt-security/setup-takumi-guard-npm@8f53b50568e4466f2d92504f349c05b9ffcb8b59 # v1
+
     - name: Bun Install
       shell: bash
       run: bun i --frozen-lockfile --ignore-scripts

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://npm.flatt.tech/


### PR DESCRIPTION
## Overview

Add [Shisho Cloud Takumi Guard](https://shisho.dev/docs/ja/t/guard/quickstart/npm) to the `setup-bun` composite action to protect npm dependencies from supply chain attacks.

## Feature type

- [x] Other (Update docs, Configure CI, etc...)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/dassssshers/nilts/blob/main/CONTRIBUTING.md) docs.
- [ ] I have written an related issue or linked with existing issues.
- [x] I have written tests and passed all of them.
    - Use `melos test` to run tests.
- [x] I have updated docs (if needed).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dassssshers/nilts/pull/470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
