### PR TITLE
build: add zizmor for GitHub Actions security linting and fix detected warnings

### DIFF
--- a/.github/actions/select-xcode/action.yml
+++ b/.github/actions/select-xcode/action.yml
@@ -16,4 +16,6 @@ runs:
     - name: Select Xcode version
       shell: bash
       run: |
-        sudo xcode-select -s "/Applications/Xcode_${{ steps.version.outputs.xcode_version }}.app/Contents/Developer"
+        sudo xcode-select -s "/Applications/Xcode_${STEPS_VERSION_OUTPUTS_XCODE_VERSION}.app/Contents/Developer"
+      env:
+        STEPS_VERSION_OUTPUTS_XCODE_VERSION: ${{ steps.version.outputs.xcode_version }}

--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -11,9 +11,11 @@ runs:
       id: extract_distribution_and_version
       shell: bash
       run: |
-        java=${{ steps.asdf.outputs.java }}
+        java=${STEPS_ASDF_OUTPUTS_JAVA}
         echo "distribution=$(echo $java | cut -d '-' -f 1)" >> $GITHUB_OUTPUT
         echo "version=$(echo $java | cut -d '-' -f 2)" >> $GITHUB_OUTPUT
+      env:
+        STEPS_ASDF_OUTPUTS_JAVA: ${{ steps.asdf.outputs.java }}
     - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         distribution: ${{ steps.extract_distribution_and_version.outputs.distribution }}

--- a/.github/workflows/auto-asign.yml
+++ b/.github/workflows/auto-asign.yml
@@ -21,6 +21,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          ASSIGNEE: ${{ github.actor }}
         with:
           script: |
             const assignees = context.payload.pull_request.assignees
@@ -29,6 +31,6 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                assignees: `${{ github.actor }}`,
+                assignees: process.env.ASSIGNEE,
               })
             }

--- a/.github/workflows/auto-asign.yml
+++ b/.github/workflows/auto-asign.yml
@@ -10,6 +10,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   assign:
     if: |
@@ -27,10 +29,10 @@ jobs:
           script: |
             const assignees = context.payload.pull_request.assignees
             if (!assignees || assignees.length === 0) {
-              github.rest.issues.addAssignees({
+              await github.rest.issues.addAssignees({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                assignees: process.env.ASSIGNEE,
+                assignees: [process.env.ASSIGNEE],
               })
             }

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -25,11 +25,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
       - name: Format with Prettier
         run: bun fmt
+
+      - name: Setup zizmor
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          install_args: zizmor
+      - name: Auto fix workflows
+        run: bun fix
 
       - name: Setup Flutter
         uses: ./.github/actions/setup-flutter

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
-      - name: Format with Prettier
-        run: bun fmt
 
       - name: Setup zizmor
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -39,6 +37,9 @@ jobs:
           install_args: zizmor
       - name: Auto fix workflows
         run: bun fix
+
+      - name: Format with Prettier
+        run: bun fmt
 
       - name: Setup Flutter
         uses: ./.github/actions/setup-flutter

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -37,6 +37,7 @@ jobs:
           install_args: zizmor
       - name: Auto fix workflows
         run: bun fix
+        continue-on-error: true
 
       - name: Format with Prettier
         run: bun fmt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,24 +18,53 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Setup Flutter
         uses: ./.github/actions/setup-flutter
       - name: Analyze
         run: melos lint
 
-  test:
+  lint_workflows:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+      - name: Setup zizmor
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          install_args: zizmor
+      - name: Lint
+        run: bun lint
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Setup Flutter
         uses: ./.github/actions/setup-flutter
       - name: Test
@@ -44,9 +73,13 @@ jobs:
   build_example_android:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Setup Java
         uses: ./.github/actions/setup-java
       - name: Setup Flutter
@@ -57,9 +90,13 @@ jobs:
   build_example_ios:
     runs-on: macos-26
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Select Xcode
         uses: ./.github/actions/select-xcode
       - name: Setup Flutter

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -8,9 +8,7 @@ on:
       - synchronize
       - reopened
 
-permissions:
-  pull-requests: read
-  statuses: write
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,6 +17,9 @@ concurrency:
 jobs:
   check_pr_title:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      statuses: write
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,6 +93,7 @@ jobs:
   publish_nilts:
     if: startsWith(github.ref, 'refs/tags/nilts-v')
     permissions:
+      contents: read
       id-token: write # Required for authentication using OIDC
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
     with:
@@ -102,6 +103,7 @@ jobs:
   publish_nilts_clock:
     if: startsWith(github.ref, 'refs/tags/nilts_clock-v')
     permissions:
+      contents: read
       id-token: write # Required for authentication using OIDC
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
     with:
@@ -111,6 +113,7 @@ jobs:
   publish_nilts_core:
     if: startsWith(github.ref, 'refs/tags/nilts_core-v')
     permissions:
+      contents: read
       id-token: write # Required for authentication using OIDC
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
     with:
@@ -120,6 +123,7 @@ jobs:
   publish_nilts_flutter_hooks:
     if: startsWith(github.ref, 'refs/tags/nilts_flutter_hooks-v')
     permissions:
+      contents: read
       id-token: write # Required for authentication using OIDC
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
     with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,14 +19,20 @@ on:
       - 'nilts_core-v[0-9]+.[0-9]+.[0-9]+*'
       - 'nilts_flutter_hooks-v[0-9]+.[0-9]+.[0-9]+*'
 
+permissions: {}
+
 jobs:
   publish_dry_run_nilts:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: github.head_ref == 'release-please--branches--main--components--nilts'
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Setup Flutter
         uses: ./.github/actions/setup-flutter
       - name: Publish - dry run
@@ -37,9 +43,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: github.head_ref == 'release-please--branches--main--components--nilts_clock'
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Setup Flutter
         uses: ./.github/actions/setup-flutter
       - name: Publish - dry run
@@ -50,9 +60,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: github.head_ref == 'release-please--branches--main--components--nilts_core'
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Setup Flutter
         uses: ./.github/actions/setup-flutter
       - name: Publish - dry run
@@ -63,9 +77,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: github.head_ref == 'release-please--branches--main--components--nilts_flutter_hooks'
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Setup Flutter
         uses: ./.github/actions/setup-flutter
       - name: Publish - dry run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 flutter 3.41.4
 java    temurin-17.0.17+10
 bun     1.3.12
+zizmor  1.24.1

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "nilts",
   "private": true,
   "scripts": {
-    "fmt": "prettier --write '**/*.+(md|yaml|yml|json|json5|xml)'"
+    "fix": "zizmor --fix .",
+    "fmt": "prettier --write '**/*.+(md|yaml|yml|json|json5|xml)'",
+    "lint": "zizmor ."
   },
   "devDependencies": {
     "@prettier/plugin-xml": "3.4.2",


### PR DESCRIPTION
## Overview

Introduce [zizmor](https://docs.zizmor.sh/) for GitHub Actions static analysis and fix all warnings it detected on our existing workflows and composite actions.

- Manage zizmor version via `.tool-versions` (`zizmor 1.24.1`, installed via `jdx/mise-action`).
- Add `bun lint` (`zizmor .`) and `bun fix` (`zizmor --fix .`) scripts to `package.json`.
- Add a `lint_workflows` job to `build.yml` that runs `bun lint`.
- Add a `bun fix` step to `autofix.yml` so fixable findings are auto-applied.
- Fix all warnings surfaced by zizmor:
  - **artipacked (9):** add `persist-credentials: false` to every `actions/checkout` invocation.
  - **excessive-permissions (10):** add workflow-level `permissions: {}` and minimal job-level `permissions` to `build.yml` / `publish.yml`.
  - **template-injection (3):** move `${{ github.actor }}` / `${{ steps.*.outputs.* }}` into `env:` blocks in `auto-asign.yml`, `select-xcode/action.yml`, and `setup-java/action.yml`.

After the fixes, `zizmor .` reports `No findings to report. Good job! (24 suppressed)`.

## Feature type

- [ ] Lint Rule
- [ ] Quick fix
- [ ] Assist
- [x] Other (Update docs, Configure CI, etc...)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/dassssshers/nilts/blob/main/CONTRIBUTING.md) docs.
- [ ] I have written an related issue or linked with existing issues.
- [x] I have written tests and passed all of them.
    - Use `melos test` to run tests.
- [x] I have updated docs (if needed).